### PR TITLE
GraphQl Support

### DIFF
--- a/Controller/BaseController.php
+++ b/Controller/BaseController.php
@@ -2,6 +2,9 @@
 
 namespace Razorpay\Magento\Controller;
 
+// require in case of zip installation without composer
+require_once __DIR__ . "/../../Razorpay/Razorpay.php";
+
 use Razorpay\Api\Api;
 use Razorpay\Magento\Model\Config;
 use Magento\Framework\App\RequestInterface;

--- a/Model/PaymentMethod.php
+++ b/Model/PaymentMethod.php
@@ -225,6 +225,109 @@ class PaymentMethod extends \Magento\Payment\Model\Method\AbstractMethod
             }
             else
             {
+                if(empty($request['query']) === false)
+                {
+
+                    $_objectManager  = \Magento\Framework\App\ObjectManager::getInstance();
+
+                    $orderLinkCollection = $_objectManager
+                                                ->get('Razorpay\Magento\Model\OrderLink')
+                                                ->getCollection()
+                                                ->addFilter('quote_id', $order->getQuoteId())
+                                                ->getFirstItem();
+
+                    $orderLink = $orderLinkCollection->getData();
+
+                    if (empty($orderLink['entity_id']) === false)
+                    {
+                        $payment_id = $orderLink['rzp_payment_id'];
+
+                        $rzp_order_id = $orderLink['rzp_order_id'];
+                        $rzp_signature = $orderLink['rzp_signature'];
+
+                        if((empty($payment_id) === true) and
+                           (empty($rzp_order_id) === true))
+                        {
+                            throw new LocalizedException(__("Razorpay Payment details missing."));
+                        }
+
+                        try
+                        {
+                            //fetch the payment from API and validate the amount
+                            $payment_data = $this->rzp->payment->fetch($payment_id);
+                        }
+                        catch(\Razorpay\Api\Errors\Error $e)
+                        {
+                           $this->_logger->critical($e);
+                           throw new LocalizedException(__('Razorpay Error: %1.', $e->getMessage()));
+                        }
+
+                        if(($payment_data->order_id === $rzp_order_id) and
+                           ($payment_data->status === 'captured'))
+                        {
+                            try
+                            {
+                                //fetch order from API
+                                $rzp_order_data = $this->rzp->order->fetch($rzp_order_id);
+                            }
+                            catch(\Razorpay\Api\Errors\Error $e)
+                            {
+                               $this->_logger->critical($e);
+                               throw new LocalizedException(__('Razorpay Error: %1.', $e->getMessage()));
+                            }
+
+                            //verify order receipt
+                            if($rzp_order_data->receipt !== $order->getQuoteId())
+                            {
+                                throw new LocalizedException(__("Not a valid Razorpay Payment"));
+                            }
+
+                            //verify currency
+                            if($payment_data->currency !== $order->getOrderCurrencyCode())
+                            {
+                                throw new LocalizedException(__("Order Currency:(%1) not matched with payment currency:(%2)", $order->getOrderCurrencyCode(), $payment_data->currency));
+                            }
+
+                            $orderAmount = (int) (number_format($order->getGrandTotal() * 100, 0, ".", ""));
+
+                            if($orderAmount !== $payment_data->amount)
+                            {
+                                 $rzpOrderAmount = $order->getOrderCurrency()->formatTxt(number_format($payment_data->amount / 100, 2, ".", ""));
+
+                                throw new LocalizedException(__("Cart order amount = %1 doesn't match with amount paid = %2", $order->getOrderCurrency()->formatTxt($order->getGrandTotal()), $rzpOrderAmount));
+                            }
+                        }
+                        else
+                        {
+                            throw new LocalizedException(__("Not a valid Razorpay Payments."));
+                        }
+
+                        $attributes = array(
+                            'razorpay_payment_id' => $payment_id,
+                            'razorpay_order_id'   => $rzp_order_id,
+                            'razorpay_signature'  => $rzp_signature
+                        );
+
+                        $this->rzp->utility->verifyPaymentSignature($attributes);
+
+                        $payment->setStatus(self::STATUS_APPROVED)
+                                ->setAmountPaid($orderAmount)
+                                ->setLastTransId($payment_id)
+                                ->setTransactionId($payment_id)
+                                ->setIsTransactionClosed(true)
+                                ->setShouldCloseParentTransaction(true);
+
+                        //update the Razorpay payment with corresponding created order ID of this quote ID
+                        $this->updatePaymentNote($payment_id, $order, $rzp_order_id, $isWebhookCall);
+
+                        return $this;
+                    }
+                    else
+                    {
+                        throw new LocalizedException(__("Razorpay Payment details missing."));
+                    }
+                }
+
                 $payment_id = $request['paymentMethod']['additional_data']['rzp_payment_id'];
 
                 $rzp_order_id = $this->order->getOrderId();

--- a/Model/PaymentMethod.php
+++ b/Model/PaymentMethod.php
@@ -225,21 +225,110 @@ class PaymentMethod extends \Magento\Payment\Model\Method\AbstractMethod
             }
             else
             {
-                $payment_id = $request['paymentMethod']['additional_data']['rzp_payment_id'];
-
-                $rzp_order_id = $this->order->getOrderId();
-
-                //validate RzpOrderamount with quote/order amount before signature
-                $orderAmount = (int) (number_format($order->getGrandTotal() * 100, 0, ".", ""));
-
-                if ($orderAmount !== $this->order->getRazorpayOrderAmount())
+                //check for GraphQL
+                if(empty($request['query']) === false)
                 {
-                    $rzpOrderAmount = $order->getOrderCurrency()->formatTxt(number_format($this->order->getRazorpayOrderAmount() / 100, 2, ".", ""));
 
-                    throw new LocalizedException(__("Cart order amount = %1 doesn't match with amount paid = %2", $order->getOrderCurrency()->formatTxt($order->getGrandTotal()), $rzpOrderAmount));
+                    //update orderLink
+                    $_objectManager  = \Magento\Framework\App\ObjectManager::getInstance();
+
+                    $orderLinkCollection = $_objectManager->get('Razorpay\Magento\Model\OrderLink')
+                                                               ->getCollection()
+                                                               ->addFilter('quote_id', $order->getQuoteId())
+                                                               ->getFirstItem();
+
+                    $orderLink = $orderLinkCollection->getData();
+
+                    if (empty($orderLink['entity_id']) === false)
+                    {
+                        $payment_id = $orderLink['rzp_payment_id'];
+
+                        $rzp_order_id = $orderLink['rzp_order_id'];
+
+                        if((empty($payment_id) === true) and
+                           (emprty($rzp_order_id) === true))
+                        {
+                            throw new LocalizedException(__("Razorpay Payment details missing."));
+                        }
+
+                        try
+                        {
+                            //fetch the payment from API and validate the amount
+                            $payment_data = $this->rzp->payment->fetch($payment_id);
+                        }
+                        catch(\Razorpay\Api\Errors\Error $e)
+                        {
+                           $this->_logger->critical($e);
+                           throw new LocalizedException(__('Razorpay Error: %1.', $e->getMessage()));
+                        }
+
+                        if(($payment_data->order_id === $rzp_order_id) and
+                           ($payment_data->status === 'captured'))
+                        {
+                            try
+                            {
+                                //fetch order from API
+                                $rzp_order_data = $this->rzp->order->fetch($rzp_order_id);
+                            }
+                            catch(\Razorpay\Api\Errors\Error $e)
+                            {
+                               $this->_logger->critical($e);
+                               throw new LocalizedException(__('Razorpay Error: %1.', $e->getMessage()));
+                            }
+
+                            //verify order receipt
+                            if($rzp_order_data->receipt !== $order->getQuoteId())
+                            {
+                                throw new LocalizedException(__("Not a valid Razorpay Payment"));
+                            }
+
+                            //verify currency
+                            if($payment_data->currency !== $order->getOrderCurrencyCode())
+                            {
+                                throw new LocalizedException(__("Order Currency:(%1) not matched with payment currency:(%2)", $order->getOrderCurrencyCode(), $payment_data->currency));
+                            }
+
+                            $orderAmount = (int) (number_format($order->getGrandTotal() * 100, 0, ".", ""));
+
+                            if($orderAmount !== $payment_data->amount)
+                            {
+                                 $rzpOrderAmount = $order->getOrderCurrency()->formatTxt(number_format($payment_data->amount / 100, 2, ".", ""));
+
+                                throw new LocalizedException(__("Cart order amount = %1 doesn't match with amount paid = %2", $order->getOrderCurrency()->formatTxt($order->getGrandTotal()), $rzpOrderAmount));
+                            }
+                        }
+                        else
+                        {
+                            throw new LocalizedException(__("Not a valid Razorpay Payments."));
+                        }
+
+                    }
+                    else
+                    {
+                        throw new LocalizedException(__("Razorpay Payment details missing."));
+                    }
                 }
+                else
+                {
+                    // Order processing through front-end
 
-                $this->validateSignature($request);
+                    $payment_id = $request['paymentMethod']['additional_data']['rzp_payment_id'];
+
+                    $rzp_order_id = $this->order->getOrderId();
+
+                    //validate RzpOrderamount with quote/order amount before signature
+                    $orderAmount = (int) (number_format($order->getGrandTotal() * 100, 0, ".", ""));
+
+                    if ($orderAmount !== $this->order->getRazorpayOrderAmount())
+                    {
+                        $rzpOrderAmount = $order->getOrderCurrency()->formatTxt(number_format($this->order->getRazorpayOrderAmount() / 100, 2, ".", ""));
+
+                        $abcAmount = $order->getGrandTotal();
+                        throw new LocalizedException(__("Cart order amount = %1 doesn't match with amount paid = %2", $order->getOrderCurrency()->formatTxt($order->getGrandTotal()), $rzpOrderAmount));
+                    }
+
+                    $this->validateSignature($request);
+                }
             }
 
             $payment->setStatus(self::STATUS_APPROVED)

--- a/Model/Resolver/CreateRazorpayOrder.php
+++ b/Model/Resolver/CreateRazorpayOrder.php
@@ -1,0 +1,125 @@
+<?php
+declare (strict_types = 1);
+
+namespace Razorpay\Magento\Model\Resolver;
+
+require_once __DIR__ . "/../../../Razorpay/Razorpay.php";
+
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\QuoteGraphQl\Model\Cart\GetCartForUser;
+use Magento\Quote\Api\CartManagementInterface;
+use Razorpay\Api\Api;
+
+class CreateRazorpayOrder implements ResolverInterface
+{
+
+    protected $scopeConfig;
+
+    protected $cartManagement;
+
+    public function __construct(
+        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
+        GetCartForUser $getCartForUser,
+        \Magento\Quote\Api\CartManagementInterface $cartManagement
+    ) {
+        $this->scopeConfig    = $scopeConfig;
+        $this->getCartForUser = $getCartForUser;
+        $this->cartManagement = $cartManagement;
+    }
+
+    /**
+     * @param GetCartForUser $getCartForUser
+     * @inheritdoc
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+        if (empty($args['cart_id'])) {
+            throw new GraphQlInputException(__('Required parameter "cart_id" is missing'));
+        }
+        try
+        {
+            $storeScope = \Magento\Store\Model\ScopeInterface::SCOPE_STORE;
+            $key        = $this->scopeConfig->getValue('payment/razorpay/key_id', $storeScope);
+            $key_secret = $this->scopeConfig->getValue('payment/razorpay/key_secret', $storeScope);
+            $this->rzp  = new Api($key, $key_secret);
+
+            $storeId = (int) $context->getExtensionAttributes()->getStore()->getId();
+
+            $maskedCartId = $args['cart_id'];
+
+            $cart            = $this->getCartForUser->execute($maskedCartId, $context->getUserId(), $storeId);
+            $receipt_id      = $cart->getId();
+            $amount          = (int) (number_format($cart->getGrandTotal() * 100, 0, ".", ""));
+            $payment_action  = $this->scopeConfig->getValue('payment/razorpay/payment_action', $storeScope);
+            $payment_capture = 1;
+            if ($payment_action === 'authorize') {
+                $payment_capture = 0;
+            }
+            $order = $this->rzp->order->create([
+                'amount'          => $amount,
+                'receipt'         => $receipt_id,
+                'currency'        => $cart->getQuoteCurrencyCode(),
+                'payment_capture' => $payment_capture,
+                'app_offer'       => (($cart->getBaseSubtotal() - $cart->getBaseSubtotalWithDiscount()) > 0) ? 1 : 0,
+            ]);
+
+            if (null !== $order && !empty($order->id)) {
+
+                $responseContent = [
+                    'success'        => true,
+                    'rzp_order'      => $order->id,
+                    'order_id'       => $receipt_id,
+                    'amount'         => $order->amount,
+                    'quote_currency' => $cart->getQuoteCurrencyCode(),
+                    'quote_amount'   => number_format((float) $cart->getGrandTotal(), 2, ".", ""),
+                    'message'        => '',
+                ];
+                $this->_objectManager = \Magento\Framework\App\ObjectManager::getInstance();
+
+                //save to razorpay orderLink
+                $orderLinkCollection = $this->_objectManager
+                    ->get('Razorpay\Magento\Model\OrderLink')
+                    ->getCollection()
+                    ->addFilter('quote_id', $receipt_id)
+                    ->getFirstItem();
+
+                $orderLinkData = $orderLinkCollection->getData();
+
+                if (empty($orderLinkData['entity_id']) === false) {
+                    $orderLinkCollection->setRzpOrderId($order->id)
+                        ->save();
+                } else {
+                    $orderLink = $this->_objectManager->create('Razorpay\Magento\Model\OrderLink');
+                    $orderLink->setQuoteId($receipt_id)
+                        ->setRzpOrderId($order->id)
+                        ->save();
+                }
+                return $responseContent;
+            } else {
+                return [
+                    'success' => false,
+                    'message' => "Razorpay Order not generated. Something went wrong",
+
+                ];
+            }
+        } catch (\Razorpay\Api\Errors\Error $e) {
+            return [
+                'success' => false,
+                'message' => $e->getMessage(),
+            ];
+        } catch (\Exception $e) {
+            return [
+                'success' => false,
+                'message' => $e->getMessage(),
+            ];
+        }
+    }
+}

--- a/Model/Resolver/SetRzpPaymentDetailsOnCart.php
+++ b/Model/Resolver/SetRzpPaymentDetailsOnCart.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Razorpay\Magento\Model\Resolver;
+
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\QuoteGraphQl\Model\Cart\CheckCartCheckoutAllowance;
+use Magento\QuoteGraphQl\Model\Cart\GetCartForUser;
+use Magento\QuoteGraphQl\Model\Cart\SetPaymentMethodOnCart as SetPaymentMethodOnCartModel;
+use Razorpay\Magento\Model\PaymentMethod;
+
+/**
+ * Mutation resolver for setting payment method for shopping cart
+ */
+class SetRzpPaymentDetailsOnCart implements ResolverInterface
+{
+    /**
+     * @var GetCartForUser
+     */
+    private $getCartForUser;
+
+    /**
+     * @var SetPaymentMethodOnCartModel
+     */
+    private $setPaymentMethodOnCart;
+
+    /**
+     * @var CheckCartCheckoutAllowance
+     */
+    private $checkCartCheckoutAllowance;
+
+    protected $_objectManager;
+
+
+
+    /**
+     * @param GetCartForUser $getCartForUser
+     * @param SetPaymentMethodOnCartModel $setPaymentMethodOnCart
+     * @param CheckCartCheckoutAllowance $checkCartCheckoutAllowance
+     */
+    public function __construct(
+        GetCartForUser $getCartForUser,
+        SetPaymentMethodOnCartModel $setPaymentMethodOnCart,
+        CheckCartCheckoutAllowance $checkCartCheckoutAllowance,
+        PaymentMethod $paymentMethod
+    ) {
+        $this->getCartForUser = $getCartForUser;
+        $this->setPaymentMethodOnCart = $setPaymentMethodOnCart;
+        $this->checkCartCheckoutAllowance = $checkCartCheckoutAllowance;
+
+        $this->rzp = $paymentMethod->rzp;
+
+        $this->_objectManager   = \Magento\Framework\App\ObjectManager::getInstance();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null)
+    {
+        if (empty($args['input']['cart_id'])) {
+            throw new GraphQlInputException(__('Required parameter "cart_id" is missing.'));
+        }
+        $maskedCartId = $args['input']['cart_id'];
+
+        if (empty($args['input']['rzp_payment_id'])) {
+            throw new GraphQlInputException(__('Required parameter "rzp_payment_id" is missing.'));
+        }
+        $rzp_payment_id = $args['input']['rzp_payment_id'];
+
+        if (empty($args['input']['rzp_order_id'])) {
+            throw new GraphQlInputException(__('Required parameter "rzp_order_id" is missing.'));
+        }
+        $rzp_order_id = $args['input']['rzp_order_id'];
+
+        $storeId = (int)$context->getExtensionAttributes()->getStore()->getId();
+        $cart = $this->getCartForUser->execute($maskedCartId, $context->getUserId(), $storeId);
+
+
+        try
+        {
+            //fetch order from API
+            $rzp_order_data = $this->rzp->order->fetch($rzp_order_id);
+
+            if($rzp_order_data->receipt !== $cart->getId())
+            {
+                throw new GraphQlInputException(__('Not a valid Razorpay orderID'));
+            }
+
+        }
+        catch(\Razorpay\Api\Errors\Error $e)
+        {
+           throw new GraphQlInputException(__('Razorpay Error: %1.', $e->getMessage()));
+        }
+
+        try
+        {
+            //save to razorpay orderLink            
+            $orderLinkCollection = $this->_objectManager->get('Razorpay\Magento\Model\OrderLink')
+                                                   ->getCollection()
+                                                   ->addFilter('quote_id', $cart->getId())
+                                                   ->getFirstItem();
+
+            $orderLinkData = $orderLinkCollection->getData();
+
+
+            if (empty($orderLinkData['entity_id']) === false)
+            {
+                $orderLinkCollection->setRzpPaymentId($rzp_payment_id)
+                                    ->setRzpOrderId($rzp_order_id)
+                                    ->save();
+            }
+            else
+            {
+                $orderLnik = $this->_objectManager->create('Razorpay\Magento\Model\OrderLink');
+                $orderLnik->setQuoteId($cart->getId())
+                          ->setRzpPaymentId($rzp_payment_id)
+                          ->setRzpOrderId($rzp_order_id)
+                          ->save();
+            }
+
+        }
+        catch (\Exception $e)
+        {
+            throw new GraphQlInputException(__('Razorpay Error: %1.', $e->getMessage()));
+        }
+
+        return [
+            'cart' => [
+                'model' => $cart,
+            ],
+        ];
+    }
+}

--- a/Model/Resolver/SetRzpPaymentDetailsOnCart.php
+++ b/Model/Resolver/SetRzpPaymentDetailsOnCart.php
@@ -1,0 +1,132 @@
+<?php
+
+declare (strict_types = 1);
+
+namespace Razorpay\Magento\Model\Resolver;
+
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\QuoteGraphQl\Model\Cart\CheckCartCheckoutAllowance;
+use Magento\QuoteGraphQl\Model\Cart\GetCartForUser;
+use Magento\QuoteGraphQl\Model\Cart\SetPaymentMethodOnCart as SetPaymentMethodOnCartModel;
+use Razorpay\Magento\Model\PaymentMethod;
+
+/**
+ * Mutation resolver for setting payment method for shopping cart
+ */
+class SetRzpPaymentDetailsOnCart implements ResolverInterface
+{
+    /**
+     * @var GetCartForUser
+     */
+    private $getCartForUser;
+
+    /**
+     * @var SetPaymentMethodOnCartModel
+     */
+    private $setPaymentMethodOnCart;
+
+    /**
+     * @var CheckCartCheckoutAllowance
+     */
+    private $checkCartCheckoutAllowance;
+
+    protected $_objectManager;
+
+    /**
+     * @param GetCartForUser $getCartForUser
+     * @param SetPaymentMethodOnCartModel $setPaymentMethodOnCart
+     * @param CheckCartCheckoutAllowance $checkCartCheckoutAllowance
+     */
+    public function __construct(
+        GetCartForUser $getCartForUser,
+        SetPaymentMethodOnCartModel $setPaymentMethodOnCart,
+        CheckCartCheckoutAllowance $checkCartCheckoutAllowance,
+        PaymentMethod $paymentMethod
+    ) {
+        $this->getCartForUser             = $getCartForUser;
+        $this->setPaymentMethodOnCart     = $setPaymentMethodOnCart;
+        $this->checkCartCheckoutAllowance = $checkCartCheckoutAllowance;
+
+        $this->rzp = $paymentMethod->rzp;
+
+        $this->_objectManager = \Magento\Framework\App\ObjectManager::getInstance();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null)
+    {
+        if (empty($args['input']['cart_id'])) {
+            throw new GraphQlInputException(__('Required parameter "cart_id" is missing.'));
+        }
+        $maskedCartId = $args['input']['cart_id'];
+
+        if (empty($args['input']['rzp_payment_id'])) {
+            throw new GraphQlInputException(__('Required parameter "rzp_payment_id" is missing.'));
+        }
+        $rzp_payment_id = $args['input']['rzp_payment_id'];
+
+        if (empty($args['input']['rzp_order_id'])) {
+            throw new GraphQlInputException(__('Required parameter "rzp_order_id" is missing.'));
+        }
+        $rzp_order_id = $args['input']['rzp_order_id'];
+
+        if (empty($args['input']['rzp_signature'])) {
+            throw new GraphQlInputException(__('Required parameter "rzp_signature" is missing.'));
+        }
+        $rzp_signature = $args['input']['rzp_signature'];
+
+        $storeId = (int) $context->getExtensionAttributes()->getStore()->getId();
+        $cart    = $this->getCartForUser->execute($maskedCartId, $context->getUserId(), $storeId);
+
+        try
+        {
+            //fetch order from API
+            $rzp_order_data = $this->rzp->order->fetch($rzp_order_id);
+            if ($rzp_order_data->receipt !== $cart->getId()) {
+                throw new GraphQlInputException(__('Not a valid Razorpay orderID'));
+            }
+
+        } catch (\Razorpay\Api\Errors\Error $e) {
+            throw new GraphQlInputException(__('Razorpay Error: %1.', $e->getMessage()));
+        }
+
+        try
+        {
+            //save to razorpay orderLink
+            $orderLinkCollection = $this->_objectManager->get('Razorpay\Magento\Model\OrderLink')
+                ->getCollection()
+                ->addFilter('quote_id', $cart->getId())
+                ->getFirstItem();
+
+            $orderLinkData = $orderLinkCollection->getData();
+
+            if (empty($orderLinkData['entity_id']) === false) {
+                $orderLinkCollection->setRzpPaymentId($rzp_payment_id)
+                    ->setRzpOrderId($rzp_order_id)
+                    ->setRzpSignature($rzp_signature)
+                    ->save();
+            } else {
+                $orderLnik = $this->_objectManager->create('Razorpay\Magento\Model\OrderLink');
+                $orderLnik->setQuoteId($cart->getId())
+                    ->setRzpPaymentId($rzp_payment_id)
+                    ->setRzpOrderId($rzp_order_id)
+                    ->setRzpSignature($rzp_signature)
+                    ->save();
+            }
+
+        } catch (\Exception $e) {
+            throw new GraphQlInputException(__('Razorpay Error: %1.', $e->getMessage()));
+        }
+
+        return [
+            'cart' => [
+                'model' => $cart,
+            ],
+        ];
+    }
+}

--- a/Model/Resolver/SetRzpPaymentDetailsOnCart.php
+++ b/Model/Resolver/SetRzpPaymentDetailsOnCart.php
@@ -99,7 +99,7 @@ class SetRzpPaymentDetailsOnCart implements ResolverInterface
 
         try
         {
-            //save to razorpay orderLink            
+            //save to razorpay orderLink
             $orderLinkCollection = $this->_objectManager->get('Razorpay\Magento\Model\OrderLink')
                                                    ->getCollection()
                                                    ->addFilter('quote_id', $cart->getId())

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -72,6 +72,14 @@ class UpgradeSchema implements  UpgradeSchemaInterface
                 ]
             )
             ->addColumn(
+                'rzp_signature',
+                Table::TYPE_TEXT,
+                25,
+                [
+                    'nullable' => true
+                ]
+            )
+            ->addColumn(
                 'by_webhook',
                 Table::TYPE_BOOLEAN,
                 1,

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -5,6 +5,7 @@
 	        <module name="Magento_Sales" />
 	        <module name="Magento_Payment" />
 	        <module name="Magento_Config" />
+	        <module name="Magento_GraphQl"/>
 	    </sequence>
 	</module>
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -5,6 +5,7 @@
 	        <module name="Magento_Sales" />
 	        <module name="Magento_Payment" />
 	        <module name="Magento_Config" />
+			<module name="Magento_GraphQl"/>
 	    </sequence>
 	</module>
 </config>

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -1,0 +1,14 @@
+type Mutation {
+	setRzpPaymentDetailsOnCart(input: SetRzpPaymentDetailsOnCartInput): SetRzpPaymentDetailsOnCartOutput @resolver(class: "Razorpay\\Magento\\Model\\Resolver\\SetRzpPaymentDetailsOnCart")
+}
+
+input SetRzpPaymentDetailsOnCartInput {
+	cart_id: String!	
+	rzp_payment_id: String!
+	rzp_order_id: String!
+}
+
+type SetRzpPaymentDetailsOnCartOutput {
+    cart: Cart!
+}
+

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -3,7 +3,7 @@ type Mutation {
 }
 
 input SetRzpPaymentDetailsOnCartInput {
-	cart_id: String!	
+	cart_id: String!
 	rzp_payment_id: String!
 	rzp_order_id: String!
 }

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -1,0 +1,24 @@
+type Mutation {
+    createRazorpayOrder (
+		cart_id: String @doc(description: "cart_id to generate Razorpay Order.")
+    ) : RazorpayOrder @resolver( class: "Razorpay\\Magento\\Model\\Resolver\\CreateRazorpayOrder") @doc(description: "Create Razorpay Order.")
+    setRzpPaymentDetailsOnCart(input: SetRzpPaymentDetailsOnCartInput): SetRzpPaymentDetailsOnCartOutput @resolver(class: "Razorpay\\Magento\\Model\\Resolver\\SetRzpPaymentDetailsOnCart")
+}
+type RazorpayOrder {
+	success: Boolean!
+	rzp_order: String
+	order_id: String
+	amount: String
+	quote_currency: String
+	quote_amount: String
+	message: String
+}
+input SetRzpPaymentDetailsOnCartInput {
+	cart_id: String!	
+	rzp_payment_id: String!
+	rzp_order_id: String!
+	rzp_signature: String!
+}
+type SetRzpPaymentDetailsOnCartOutput {
+    cart: Cart!
+}


### PR DESCRIPTION
## Razorpay GraphQl Extension

This is the Order Flow for placing Magento Order using razorpay with graphql 

1. set Payment Method on Cart
```
mutation {
  setPaymentMethodOnCart(input: {
      cart_id: "F8MruNi2R7tiZqo8Pkglxaz370VrUnCu"
      payment_method: {
          code: "razorpay"
      }
  }) {
    cart {
      selected_payment_method {
        code
      }
    }
  }
}
```

2. Create Razorpay Order against the cart total(just after the final placeorder button click)
```
mutation {
  createRazorpayOrder (
    cart_id: "F8MruNi2R7tiZqo8Pkglxaz370VrUnCu"
  ){
    success
    rzp_order
    order_id
    amount
    message
  }
}
```

3. Generate Payment from the Frontend/React/using razorpay's checkout.js & obtain razorpay_payment_id & razorpay_signature

4. Save Razorpay Response Details against Cart after payment success 
```
mutation {
  setRzpPaymentDetailsOnCart (
    input: {
      cart_id: "F8MruNi2R7tiZqo8Pkglxaz370VrUnCu"
      rzp_payment_id: "pay_GmVq2o9VzEQkPL"
      rzp_order_id: "order_GmVovQtWtOsquw"
      rzp_signature: "c95c961f7f4682e932f8dfc7d52e87c5f0dff43bce81efa86ad80a7c808983b7"
    }
  ){
  cart{
    id
  }
  }
}
```
5. Finally Place Magento Order 
```
mutation {
  placeOrder(input: {cart_id: "F8MruNi2R7tiZqo8Pkglxaz370VrUnCu"}) {
    order {
      order_number
    }
  }
}
```